### PR TITLE
Fix to Nalu not building with openfast

### DIFF
--- a/configs/custom-package-files/openfast/package.py
+++ b/configs/custom-package-files/openfast/package.py
@@ -76,6 +76,7 @@ class Openfast(CMakePackage):
                 '-DMPI_Fortran_COMPILER:PATH=%s' % spec['mpi'].mpifc,
                 '-DHDF5_ROOT:PATH=%s' % spec['hdf5'].prefix,
                 '-DYAML_ROOT:PATH=%s' % spec['yaml-cpp'].prefix,
+                '-DBUILD_FAST_CPP_API:BOOL=%s' % 'ON',
             ])
 
             if '~shared' in spec:


### PR DESCRIPTION
Up to you to decide if you want to make this a variant. This is my fix.  Nalu-wind can't build with OpenFAST without this change 