### PR TITLE
No MPI compiler wrappers for AMR-Wind GPU builds

### DIFF
--- a/test-scripts/test-amr-wind.sh
+++ b/test-scripts/test-amr-wind.sh
@@ -262,11 +262,11 @@ test_configuration() {
     CXX_COMPILER=mpicxx
     C_COMPILER=mpicc
     FORTRAN_COMPILER=mpifort
-    #if [ "${MACHINE_NAME}" == 'eagle' ]; then
-    #  CXX_COMPILER=g++
-    #  C_COMPILER=gcc
-    #  FORTRAN_COMPILER=gfortran
-    #fi
+    if [ "${MACHINE_NAME}" == 'eagle' ]; then
+      CXX_COMPILER=g++
+      C_COMPILER=gcc
+      FORTRAN_COMPILER=gfortran
+    fi
   elif [ "${COMPILER_NAME}" == 'intel' ]; then
     CXX_COMPILER=mpiicpc
     C_COMPILER=mpiicc


### PR DESCRIPTION
Do not use MPI compiler wrappers for building AMR-Wind with CUDA... this causes link errors for the PlotFile tools.